### PR TITLE
Added an ability to authenticate using API tokens

### DIFF
--- a/packages/dev/README.md
+++ b/packages/dev/README.md
@@ -16,6 +16,13 @@ CLOUDFLARE_ACCOUNT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 CLOUDFLARE_WORKERS_DEV_PROJECT=xxxxxx
 ```
 
+Please note that `cfworker` supports two authentication options:
+
+  1. using API tokens, where you can provide fine-graned permission scopes (e.g. to deploy this package you may want to create a token using the "Edit Cloudflare Workers" template in CloudFlare's console;
+  2. using your API key, where you basically grant `cfworker` to do API calls on your behalf (e.g. the code will have full and unrestricted access to everything in your CloudFlare account).
+
+If you prefer option 1, then put your API token into CLOUDFLARE_API_KEY and ensure that CLOUDFLARE_EMAIL is not defined in your `.env` file.  Otherwise, to use option 2, put your API key into CLOUDFLARE_API_KEY and configure CLOUDFLARE_EMAIL to your e-mail used to access your account.
+
 Usage:
 
 ```

--- a/packages/dev/src/cli/deploy-command.js
+++ b/packages/dev/src/cli/deploy-command.js
@@ -19,18 +19,20 @@ export class DeployDevCommand {
       CLOUDFLARE_WORKERS_DEV_PROJECT = args.project
     } = process.env;
 
+    if (!CLOUDFLARE_API_KEY) {
+      throw new Error(
+        'CLOUDFLARE_API_KEY environment variable is not defined.'
+      );
+/** XXX - if email is not specified then CLOUDFLARE_API_KEY must be an API token
     if (!CLOUDFLARE_EMAIL) {
       throw new Error('CLOUDFLARE_EMAIL environment variable is not defined.');
     }
+*/
     if (!CLOUDFLARE_ACCOUNT_ID) {
       throw new Error(
         'CLOUDFLARE_ACCOUNT_ID environment variable is not defined.'
       );
     }
-    if (!CLOUDFLARE_API_KEY) {
-      throw new Error(
-        'CLOUDFLARE_API_KEY environment variable is not defined.'
-      );
     }
 
     this.accountEmail = CLOUDFLARE_EMAIL;
@@ -97,9 +99,11 @@ export class DeployCommand {
       CLOUDFLARE_ZONE_ID
     } = process.env;
 
+/** XXX
     if (!CLOUDFLARE_EMAIL) {
       throw new Error('CLOUDFLARE_EMAIL environment variable is not defined.');
     }
+*/
     if (!CLOUDFLARE_ACCOUNT_ID) {
       throw new Error(
         'CLOUDFLARE_ACCOUNT_ID environment variable is not defined.'

--- a/packages/dev/src/cloudflare-api.js
+++ b/packages/dev/src/cloudflare-api.js
@@ -13,11 +13,11 @@ export async function getWorkersDevSubdomain(accountId, accountEmail, apiKey) {
   const response = await fetch(
     `${apiBase}/accounts/${accountId}/workers/subdomain`,
     {
-      headers: args.accountEmail ? {
-        'X-Auth-Email': args.accountEmail,
-        'X-Auth-Key': args.apiKey
+      headers: accountEmail ? {
+        'X-Auth-Email': accountEmail,
+        'X-Auth-Key': apiKey
       } : {
-        'Authorization': 'Bearer ' + args.apiKey
+        'Authorization': 'Bearer ' + apiKey
       }
     }
   );

--- a/packages/dev/src/cloudflare-api.js
+++ b/packages/dev/src/cloudflare-api.js
@@ -13,9 +13,11 @@ export async function getWorkersDevSubdomain(accountId, accountEmail, apiKey) {
   const response = await fetch(
     `${apiBase}/accounts/${accountId}/workers/subdomain`,
     {
-      headers: {
-        'X-Auth-Email': accountEmail,
-        'X-Auth-Key': apiKey
+      headers: args.accountEmail ? {
+        'X-Auth-Email': args.accountEmail,
+        'X-Auth-Key': args.apiKey
+      } : {
+        'Authorization': 'Bearer ' + args.apiKey
       }
     }
   );
@@ -60,9 +62,11 @@ export async function deployToWorkersDev(args) {
     `${apiBase}/accounts/${args.accountId}/workers/scripts/${args.project}`,
     {
       method: 'PUT',
-      headers: Object.assign({}, form.getHeaders(), {
+      headers: Object.assign({}, form.getHeaders(), args.accountEmail ? {
         'X-Auth-Email': args.accountEmail,
         'X-Auth-Key': args.apiKey
+      } : {
+        'Authorization': 'Bearer ' + args.apiKey
       }),
       body: form.getBuffer()
     }
@@ -93,9 +97,11 @@ export async function deployToWorkersDev(args) {
  * @param {DeployArgs} args
  */
 export async function deploy(args) {
-  const authHeaders = {
+  const authHeaders = args.accountEmail ? {
     'X-Auth-Email': args.accountEmail,
     'X-Auth-Key': args.apiKey
+  } : {
+    'Authorization': 'Bearer ' + args.apiKey
   };
 
   logger.progress('Getting zone...');


### PR DESCRIPTION
I do not know TypeScript, so this may look a bit hacky, yet it works as expected.

It seems that the project is still in its "storming" stage when everything is very unstable, so I think these changes are in line with the current state.  I just thought to bring a bit more security to the table here.

This PR addresses #22 and I tested that `cfworker deploy ...` works with both email/key and just a token.