### PR TITLE
fix(dev): remove ";" in shebang

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ dist
 packages/json-schema/test/json-schema-test-suite.ts
 packages/dev/test/fixtures
 .cfworker
+packages/dev/src/cli/index.js

--- a/packages/dev/src/cli/index.js
+++ b/packages/dev/src/cli/index.js
@@ -1,5 +1,5 @@
 #!/bin/sh
-':'; //# comment; exec /usr/bin/env node --experimental-json-modules --no-warnings "$0" "$@"
+':' //# comment; exec /usr/bin/env node --experimental-json-modules --no-warnings "$0" "$@"
 
 import chalk from 'chalk';
 import commander from 'commander';


### PR DESCRIPTION
Remove `;` in shebang, the `;` in shebang will cause `//#: not found` on the command line.