### PR TITLE
Add missing release arg to README example

### DIFF
--- a/packages/sentry/README.md
+++ b/packages/sentry/README.md
@@ -7,6 +7,7 @@ import { captureError } from '@cfworker/sentry';
 
 const sentryDsn = '...';
 const environment = 'production'; // development, etc.
+const release = '...';
 
 addEventListener('fetch', event => {
   try {
@@ -15,6 +16,7 @@ addEventListener('fetch', event => {
     const { event_id, promise } = captureError(
       sentryDsn,
       environment,
+      release,
       err,
       event.request,
       user // optional, eg { name: 'octocat' }


### PR DESCRIPTION
#56 introduced new release arg but README wasn't updated accordingly.