### PR TITLE
feat(jwt): Allow passing jwks

### DIFF
--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -4,6 +4,8 @@ Tiny lib for decoding JWTs and verifying signatures, using native crypto APIs.
 
 Currently supports `alg:'RS256'` only.
 
+## Usage
+
 ```js
 const jwt = request.headers.get('Authorization');
 const issuer = '...'; // Auth0 origin.
@@ -15,4 +17,13 @@ if (!result.valid) {
 } else {
   console.log(result.payload); // { iss, sub, aud, iat, exp, ...claims }
 }
+```
+
+> If your auth provider do not publish standard jwks , you can convert public key to jwks and pass it as an additional parameter.
+
+```js
+const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXV...';
+const keySet = { keys: [{ kid: 'abc', n: 'q1rk8w...' }] };
+
+await parseJwt(jwt, iss, aud, keySet);
 ```

--- a/packages/jwt/src/jwks.ts
+++ b/packages/jwt/src/jwks.ts
@@ -43,9 +43,12 @@ export async function importKey(issuer: string, jwk: JsonWebKey) {
 /**
  * Get the CryptoKey associated with the JWT's issuer.
  */
-export async function getkey(decoded: DecodedJwt): Promise<CryptoKey> {
+export async function getkey(
+  decoded: DecodedJwt,
+  keySet?: JsonWebKeyset
+): Promise<CryptoKey> {
   if (!importedKeys[decoded.payload.iss]) {
-    const jwks = await getJwks(decoded.payload.iss);
+    const jwks = keySet || (await getJwks(decoded.payload.iss));
     await importKey(decoded.payload.iss, jwks.keys[0]);
   }
   return importedKeys[decoded.payload.iss];

--- a/packages/jwt/src/parse.ts
+++ b/packages/jwt/src/parse.ts
@@ -1,5 +1,5 @@
 import { decodeJwt } from './decode.js';
-import { DecodedJwt, JwtParseResult } from './types.js';
+import { DecodedJwt, JwtParseResult, JsonWebKeyset } from './types.js';
 import { verifyJwtSignature } from './verify.js';
 
 /**
@@ -8,7 +8,8 @@ import { verifyJwtSignature } from './verify.js';
 export async function parseJwt(
   encodedToken: string,
   issuerOrigin: string,
-  audience: string
+  audience: string,
+  keySet?: JsonWebKeyset
 ): Promise<JwtParseResult> {
   let decoded: DecodedJwt;
   try {
@@ -53,7 +54,7 @@ export async function parseJwt(
   }
   let signatureValid: boolean;
   try {
-    signatureValid = await verifyJwtSignature(decoded);
+    signatureValid = await verifyJwtSignature(decoded, keySet);
   } catch {
     return { valid: false, reason: `Error verifying JWT signature.` };
   }

--- a/packages/jwt/src/verify.ts
+++ b/packages/jwt/src/verify.ts
@@ -1,16 +1,20 @@
 import { getkey } from './jwks.js';
-import { DecodedJwt } from './types.js';
+import { DecodedJwt, JsonWebKeyset } from './types.js';
 
 /**
  * Verify the JWT's signature.
  * @param {DecodedJwt} decoded
  */
-export async function verifyJwtSignature(decoded: DecodedJwt) {
+export async function verifyJwtSignature(
+  decoded: DecodedJwt,
+  keySet?: JsonWebKeyset
+) {
   const encoder = new TextEncoder();
   const data = encoder.encode(`${decoded.raw.header}.${decoded.raw.payload}`);
   const signature = new Uint8Array(
     Array.from(decoded.signature).map(c => c.charCodeAt(0))
   );
-  const key = await getkey(decoded);
+
+  const key = await getkey(decoded, keySet);
   return crypto.subtle.verify('RSASSA-PKCS1-v1_5', key, signature, data);
 }

--- a/packages/jwt/test/parse.spec.ts
+++ b/packages/jwt/test/parse.spec.ts
@@ -20,6 +20,28 @@ describe('parseJwt', () => {
     expect(result.valid).to.equal(true);
   });
 
+  it('Accepts external jwks', async () => {
+    const exp = Math.floor(new Date().getTime() / 1000) + 10;
+    const header: JwtHeader = { alg: 'RS256', typ: 'JWT', kid: 'abc' };
+    const payload = { iss, aud, exp, sub, iat };
+    const jwt = await createJwt(header, payload);
+    const result = await parseJwt(jwt, iss, aud, {
+      keys: [
+        {
+          kid: 'abc',
+          alg: 'RS256',
+          e: 'AQAB',
+          ext: true,
+          key_ops: ['verify'],
+          kty: 'RSA',
+          n:
+            'q9-bSyae6KkVo9rdgrvEW0BhfnHlSIMasKGCMbD7metqOzviVKz9_aWMUPTngwwT_gQRnXz7gUMZ8qc_E1AeX_VAcS9DQUJONJp8sogVXFABhkzQLBKg7eYn6_1tknwE-84L4toiTYduR2zwDAOWr3tfg8RI9BBwv5efTBw3SAqnedErobZqKY3ZSgI4y8hFxkYOLApZK6672HHck4gW5Xh0WY5kcKKa8jJYeqH479X_guugOBe3x7JcwpAaQKK7fH0A1F__citBsEym_VqdXlAhE_J5eiu8JWw3AkfXUUA3nPl1GmrGan1PCSmzhjxbvfwAsAQ1Y2GdWL8ErprEEw'
+        } as JsonWebKey
+      ]
+    });
+    expect(result.valid).to.equal(true);
+  });
+
   it('rejects unexpected algorithm', async () => {
     const exp = Math.floor(new Date().getTime() / 1000) + 10;
     const header: JwtHeader = { alg: 'HS256', typ: 'JWT', kid: 'xyz' };


### PR DESCRIPTION
This updates makes it possible to pass jwks as optional parameter when `parsingJWT`,`verifyJwtSignature` & `getkey`

The reasons for adding this are

- Some providers do not follow [RFC5785](https://tools.ietf.org/html/rfc5785) for jwks location. e.g [firebase](https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com)

- Some providers do not provide public keys in jwk format , in that case it will be possible to use other libraries for converting public key to jwks and use the rest of functionalities 


@jdanyow Can you review #92 first I will fix conflicts in this PR