### PR TITLE
Allow undefined environment variables

### DIFF
--- a/packages/dev/src/bundler.js
+++ b/packages/dev/src/bundler.js
@@ -121,6 +121,8 @@ export class Bundler extends EventEmitter {
       replacements[`process.env.${key}`] = JSON.stringify(value);
     }
 
+    replacements['process.env.'] = '({}).';
+
     return replacements;
   }
 }

--- a/packages/dev/src/bundler.js
+++ b/packages/dev/src/bundler.js
@@ -121,7 +121,7 @@ export class Bundler extends EventEmitter {
       replacements[`process.env.${key}`] = JSON.stringify(value);
     }
 
-    replacements['process.env.'] = '({}).';
+    replacements['process.env.'] = '({} as any).';
 
     return replacements;
   }


### PR DESCRIPTION
Hello, thanks a lot for all the projects in this repo!

Right now it crashes when using `process.env.UNDEFINED_VARIABLE` with something along the lines of "process is not defined". This happens because this undefined variable wasn't part of the `.env` files and the replacer didn't find this match.

This adds a way to prevent this error and just have undefined variables like you would have normally in Node.js.

A use case is, for example, having your CI adding `GIT_SHA` variable for production but having it undefined during dev/test.

There's also the `const { SOMETHING } = process.env` syntax, but that would require inlining all the variables with `replacements['process.env'] = JSON.stringify(process.env)` and I guess that's overkill so I didn't add it to this PR.
