### PR TITLE
add support for aws Cognito jwt 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,4 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "version": "1.6.8"
 }

--- a/packages/jwt/src/jwks.ts
+++ b/packages/jwt/src/jwks.ts
@@ -5,7 +5,7 @@ import { DecodedJwt, JsonWebKeyset } from './types.js';
  */
 export async function getJwks(issuer: string): Promise<JsonWebKeyset> {
   const url = new URL(issuer);
-  url.pathname = '/.well-known/jwks.json';
+  url.pathname += '/.well-known/jwks.json';
   const response = await fetch(url.href);
   if (!response.ok) {
     throw new Error(

--- a/packages/jwt/src/parse.ts
+++ b/packages/jwt/src/parse.ts
@@ -16,12 +16,6 @@ export async function parseJwt(
   } catch {
     return { valid: false, reason: `Unable to decode JWT.` };
   }
-  if (decoded.header.typ !== 'JWT') {
-    return {
-      valid: false,
-      reason: `Invalid JWT type "${decoded.header.typ}". Expected "JWT".`
-    };
-  }
   if (decoded.header.alg !== 'RS256') {
     return {
       valid: false,
@@ -34,8 +28,8 @@ export async function parseJwt(
       reason: `Invalid JWT audience "${decoded.payload.aud}". Expected "${audience}".`
     };
   }
-  const iss = new URL(decoded.payload.iss);
-  if (iss.origin !== issuerOrigin) {
+
+  if (decoded.payload.iss !== issuerOrigin) {
     return {
       valid: false,
       reason: `Invalid JWT issuer "${decoded.payload.iss}". Expected "${issuerOrigin}".`

--- a/packages/jwt/src/parse.ts
+++ b/packages/jwt/src/parse.ts
@@ -7,7 +7,7 @@ import { verifyJwtSignature } from './verify.js';
  */
 export async function parseJwt(
   encodedToken: string,
-  issuerOrigin: string,
+  issuer: string,
   audience: string
 ): Promise<JwtParseResult> {
   let decoded: DecodedJwt;
@@ -15,6 +15,15 @@ export async function parseJwt(
     decoded = decodeJwt(encodedToken);
   } catch {
     return { valid: false, reason: `Unable to decode JWT.` };
+  }
+  if (
+    typeof decoded.header.typ !== 'undefined' &&
+    decoded.header.typ !== 'JWT'
+  ) {
+    return {
+      valid: false,
+      reason: `Invalid JWT type "${decoded.header.typ}". Expected "JWT".`
+    };
   }
   if (decoded.header.alg !== 'RS256') {
     return {
@@ -29,10 +38,10 @@ export async function parseJwt(
     };
   }
 
-  if (decoded.payload.iss !== issuerOrigin) {
+  if (decoded.payload.iss !== issuer) {
     return {
       valid: false,
-      reason: `Invalid JWT issuer "${decoded.payload.iss}". Expected "${issuerOrigin}".`
+      reason: `Invalid JWT issuer "${decoded.payload.iss}". Expected "${issuer}".`
     };
   }
   const expiryDate = new Date(0);

--- a/packages/jwt/src/types.ts
+++ b/packages/jwt/src/types.ts
@@ -7,7 +7,7 @@ export interface JwtPayload {
 }
 
 export interface JwtHeader {
-  typ: string;
+  typ?: string;
   alg: string;
   kid: string;
 }

--- a/packages/jwt/test/decode.spec.ts
+++ b/packages/jwt/test/decode.spec.ts
@@ -8,6 +8,14 @@ describe('decodeJwt', () => {
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
   const [rawHeader, rawPayload, rawSignature] = encoded.split('.');
 
+  const encodedUndefinedType =
+    'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.GuoUe6tw79bJlbU1HU0ADX0pr0u2kf3r_4OdrDufSfQ';
+  const [
+    rawHeaderUndefinedType,
+    rawPayloadUndefinedType,
+    rawSignatureUndefinedType
+  ] = encodedUndefinedType.split('.');
+
   it('decodes a JWT', () => {
     expect(decodeJwt(encoded)).to.eql({
       header: {
@@ -24,6 +32,25 @@ describe('decodeJwt', () => {
         header: rawHeader,
         payload: rawPayload,
         signature: rawSignature
+      }
+    });
+  });
+
+  it('decodes a JWT with undefined type', () => {
+    expect(decodeJwt(encodedUndefinedType)).to.eql({
+      header: {
+        alg: 'HS256'
+      },
+      payload: {
+        sub: '1234567890',
+        name: 'John Doe',
+        iat: 1516239022
+      },
+      signature: decode(rawSignatureUndefinedType),
+      raw: {
+        header: rawHeaderUndefinedType,
+        payload: rawPayloadUndefinedType,
+        signature: rawSignatureUndefinedType
       }
     });
   });

--- a/packages/jwt/test/parse.spec.ts
+++ b/packages/jwt/test/parse.spec.ts
@@ -30,6 +30,24 @@ describe('parseJwt', () => {
     expect(result.valid).to.equal(false);
   });
 
+  it('rejects unexpected type', async () => {
+    const exp = Math.floor(new Date().getTime() / 1000) + 10;
+    const header: JwtHeader = { alg: 'RS256', typ: 'JWS', kid };
+    const payload = { iss, aud, exp, sub, iat };
+    const jwt = await createJwt(header, payload);
+    const result = await parseJwt(jwt, iss, aud);
+    expect(result.valid).to.equal(false);
+  });
+
+  it('accepts undefined type', async () => {
+    const exp = Math.floor(new Date().getTime() / 1000) + 10;
+    const header: JwtHeader = { alg: 'RS256', kid };
+    const payload = { iss, aud, exp, sub, iat };
+    const jwt = await createJwt(header, payload);
+    const result = await parseJwt(jwt, iss, aud);
+    expect(result.valid).to.equal(true);
+  });
+
   it('rejects invalid issuer', async () => {
     const exp = Math.floor(new Date().getTime() / 1000) + 60;
     const header: JwtHeader = { alg: 'RS256', typ: 'JWT', kid };

--- a/packages/jwt/test/parse.spec.ts
+++ b/packages/jwt/test/parse.spec.ts
@@ -30,15 +30,6 @@ describe('parseJwt', () => {
     expect(result.valid).to.equal(false);
   });
 
-  it('rejects unexpected type', async () => {
-    const exp = Math.floor(new Date().getTime() / 1000) + 10;
-    const header: JwtHeader = { alg: 'RS256', typ: 'JWS', kid };
-    const payload = { iss, aud, exp, sub, iat };
-    const jwt = await createJwt(header, payload);
-    const result = await parseJwt(jwt, iss, aud);
-    expect(result.valid).to.equal(false);
-  });
-
   it('rejects invalid issuer', async () => {
     const exp = Math.floor(new Date().getTime() / 1000) + 60;
     const header: JwtHeader = { alg: 'RS256', typ: 'JWT', kid };


### PR DESCRIPTION
fix to support Cognito tokens. the main differences:

1. issuer url requires a path referencing the pool id 
2. the header doesn't have a type field.  