### PR TITLE
Respect executable path env variable

### DIFF
--- a/packages/dev/src/worker-host.js
+++ b/packages/dev/src/worker-host.js
@@ -47,6 +47,7 @@ export class WorkerHost extends EventEmitter {
     const browser = (this.browser = await puppeteer.launch({
       headless: !this.inspect,
       devtools: this.inspect,
+      executablePath: puppeteer.executablePath(),
       // userDataDir: this.inspect ? './.cfworker' : undefined,
       args: [
         '--start-maximized', // https://peter.sh/experiments/chromium-command-line-switches/


### PR DESCRIPTION
Respects the [`PUPPETEER_EXECUTABLE_PATH`](https://github.com/puppeteer/puppeteer/blob/v8.0.0/docs/api.md#environment-variables) environment variable to allow specifying custom chromium binarys.

This is necessary to run `cfworker` on M1 Macs, where (as of this writing) the installation of puppeteer with the included chromium version fails. 

See also: https://github.com/puppeteer/puppeteer/issues/6622#issuecomment-787912758