### PR TITLE
Quietly fail when geojs is blocked

### DIFF
--- a/packages/dev/src/ip.js
+++ b/packages/dev/src/ip.js
@@ -4,10 +4,14 @@ import fetch from 'node-fetch';
  * @returns {Promise<string|null>}
  */
 export async function getLocalhostIP() {
-  const response = await fetch('https://get.geojs.io/v1/ip.json');
-  if (!response.ok) {
+  try {
+    const response = await fetch('https://get.geojs.io/v1/ip.json');
+    if (!response.ok) {
+      return null;
+    }
+    const data = await response.json();
+    return data.ip;
+  } catch {
     return null;
   }
-  const data = await response.json();
-  return data.ip;
 }


### PR DESCRIPTION
Quietly fail if geojs.io is blocked by the OS, same as non-200 response. Currently the launch process crashes when this is the case.