### PR TITLE
Change enableCrossPartition header for queryDocuments to true

### DIFF
--- a/.changeset/wet-ligers-sell.md
+++ b/.changeset/wet-ligers-sell.md
@@ -1,0 +1,5 @@
+---
+'@cfworker/cosmos': patch
+---
+
+Changed enableCrossPartition header for queryDocuments to default to true

--- a/packages/cosmos/src/client.ts
+++ b/packages/cosmos/src/client.ts
@@ -270,7 +270,7 @@ export class CosmosClient {
 
     const headers = Object.assign(
       {
-        enableCrossPartition: false,
+        enableCrossPartition: true,
         enableScan: false,
         maxItems: -1,
         populateMetrics: false,


### PR DESCRIPTION
RE https://github.com/cfworker/cfworker/issues/168#issuecomment-97990616 and https://github.com/jupitern/cosmosdb/issues/3

Azure has deprecated non cross partition queries and as such the `enableCrossPartition` header should default to true.