### PR TITLE
Support cross partition query operations

### DIFF
--- a/.changeset/brown-dogs-repeat.md
+++ b/.changeset/brown-dogs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@cfworker/cosmos': minor
+---
+
+Added getPartitionKeyRanges and support for cross partition query operations previously unsupported

--- a/package-lock.json
+++ b/package-lock.json
@@ -5399,10 +5399,10 @@
     },
     "packages/base64url": {
       "name": "@cfworker/base64url",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "devDependencies": {
-        "@cfworker/dev": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
         "@types/chai": "^4.2.16",
         "@types/mocha": "^8.2.2",
         "chai": "^4.3.4",
@@ -5412,15 +5412,15 @@
     },
     "packages/cosmos": {
       "name": "@cfworker/cosmos",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
-        "@cfworker/worker-types": "^1.10.1",
+        "@cfworker/worker-types": "^1.10.2",
         "@cloudflare/workers-types": "^2.1.0",
         "base64-arraybuffer": "^0.2.0"
       },
       "devDependencies": {
-        "@cfworker/dev": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
         "@types/chai": "^4.2.16",
         "@types/mocha": "^8.2.2",
         "chai": "^4.3.4",
@@ -5430,10 +5430,10 @@
     },
     "packages/csv": {
       "name": "@cfworker/csv",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "devDependencies": {
-        "@cfworker/dev": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
         "@types/chai": "^4.2.16",
         "@types/mocha": "^8.2.2",
         "chai": "^4.3.4",
@@ -5443,10 +5443,10 @@
     },
     "packages/dev": {
       "name": "@cfworker/dev",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
-        "@cfworker/worker-types": "^1.10.1",
+        "@cfworker/worker-types": "^1.10.2",
         "@cloudflare/workers-types": "^2.2.1",
         "@rollup/plugin-commonjs": "^18.0.0",
         "@rollup/plugin-json": "^4.1.0",
@@ -5512,27 +5512,27 @@
     },
     "packages/examples": {
       "name": "@cfworker/examples",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
-        "@cfworker/cosmos": "^1.10.1",
-        "@cfworker/jwt": "^1.10.1",
-        "@cfworker/sentry": "^1.10.1",
-        "@cfworker/web": "^1.10.1",
-        "@cfworker/worker-types": "^1.10.1",
+        "@cfworker/cosmos": "^1.10.2",
+        "@cfworker/jwt": "^1.10.2",
+        "@cfworker/sentry": "^1.10.2",
+        "@cfworker/web": "^1.10.2",
+        "@cfworker/worker-types": "^1.10.2",
         "@cloudflare/workers-types": "^2.1.0"
       },
       "devDependencies": {
-        "@cfworker/dev": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
         "typescript": "^4.5.2"
       }
     },
     "packages/json-schema": {
       "name": "@cfworker/json-schema",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "devDependencies": {
-        "@cfworker/dev": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
         "@types/chai": "^4.2.16",
         "@types/mocha": "^8.2.2",
         "chai": "^4.3.4",
@@ -5543,15 +5543,15 @@
     },
     "packages/jwt": {
       "name": "@cfworker/jwt",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
-        "@cfworker/base64url": "^1.10.1",
-        "@cfworker/worker-types": "^1.10.1",
+        "@cfworker/base64url": "^1.10.2",
+        "@cfworker/worker-types": "^1.10.2",
         "@cloudflare/workers-types": "^2.1.0"
       },
       "devDependencies": {
-        "@cfworker/dev": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
         "@types/chai": "^4.2.16",
         "@types/mocha": "^8.2.2",
         "chai": "^4.3.4",
@@ -5561,10 +5561,10 @@
     },
     "packages/sentry": {
       "name": "@cfworker/sentry",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
-        "@cfworker/worker-types": "^1.10.1",
+        "@cfworker/worker-types": "^1.10.2",
         "@cloudflare/workers-types": "^2.1.0"
       },
       "devDependencies": {
@@ -5573,24 +5573,24 @@
     },
     "packages/site": {
       "name": "@cfworker/site",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
-        "@cfworker/web": "^1.10.1",
-        "@cfworker/worker-types": "^1.10.1",
+        "@cfworker/web": "^1.10.2",
+        "@cfworker/worker-types": "^1.10.2",
         "@cloudflare/workers-types": "^2.1.0"
       },
       "devDependencies": {
-        "@cfworker/dev": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
         "typescript": "^4.5.2"
       }
     },
     "packages/uuid": {
       "name": "@cfworker/uuid",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "devDependencies": {
-        "@cfworker/dev": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
         "@types/chai": "^4.2.16",
         "@types/mocha": "^8.2.2",
         "chai": "^4.3.4",
@@ -5600,11 +5600,11 @@
     },
     "packages/web": {
       "name": "@cfworker/web",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
-        "@cfworker/json-schema": "^1.10.1",
-        "@cfworker/worker-types": "^1.10.1",
+        "@cfworker/json-schema": "^1.10.2",
+        "@cfworker/worker-types": "^1.10.2",
         "@cloudflare/workers-types": "^2.1.0",
         "@types/cookie": "^0.4.0",
         "@types/html-escaper": "^3.0.0",
@@ -5621,7 +5621,7 @@
         "statuses": "^1.5.0"
       },
       "devDependencies": {
-        "@cfworker/dev": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
         "@types/chai": "^4.2.16",
         "@types/mocha": "^8.2.2",
         "chai": "^4.3.4",
@@ -5632,7 +5632,7 @@
     },
     "packages/worker-types": {
       "name": "@cfworker/worker-types",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^4.5.2"
@@ -5678,7 +5678,7 @@
     "@cfworker/base64url": {
       "version": "file:packages/base64url",
       "requires": {
-        "@cfworker/dev": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
         "@types/chai": "^4.2.16",
         "@types/mocha": "^8.2.2",
         "chai": "^4.3.4",
@@ -5689,8 +5689,8 @@
     "@cfworker/cosmos": {
       "version": "file:packages/cosmos",
       "requires": {
-        "@cfworker/dev": "^1.10.1",
-        "@cfworker/worker-types": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
+        "@cfworker/worker-types": "^1.10.2",
         "@cloudflare/workers-types": "^2.1.0",
         "@types/chai": "^4.2.16",
         "@types/mocha": "^8.2.2",
@@ -5703,7 +5703,7 @@
     "@cfworker/csv": {
       "version": "file:packages/csv",
       "requires": {
-        "@cfworker/dev": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
         "@types/chai": "^4.2.16",
         "@types/mocha": "^8.2.2",
         "chai": "^4.3.4",
@@ -5714,7 +5714,7 @@
     "@cfworker/dev": {
       "version": "file:packages/dev",
       "requires": {
-        "@cfworker/worker-types": "^1.10.1",
+        "@cfworker/worker-types": "^1.10.2",
         "@cloudflare/workers-types": "^2.2.1",
         "@rollup/plugin-commonjs": "^18.0.0",
         "@rollup/plugin-json": "^4.1.0",
@@ -5769,12 +5769,12 @@
     "@cfworker/examples": {
       "version": "file:packages/examples",
       "requires": {
-        "@cfworker/cosmos": "^1.10.1",
-        "@cfworker/dev": "^1.10.1",
-        "@cfworker/jwt": "^1.10.1",
-        "@cfworker/sentry": "^1.10.1",
-        "@cfworker/web": "^1.10.1",
-        "@cfworker/worker-types": "^1.10.1",
+        "@cfworker/cosmos": "^1.10.2",
+        "@cfworker/dev": "^1.10.2",
+        "@cfworker/jwt": "^1.10.2",
+        "@cfworker/sentry": "^1.10.2",
+        "@cfworker/web": "^1.10.2",
+        "@cfworker/worker-types": "^1.10.2",
         "@cloudflare/workers-types": "^2.1.0",
         "typescript": "^4.5.2"
       }
@@ -5782,7 +5782,7 @@
     "@cfworker/json-schema": {
       "version": "file:packages/json-schema",
       "requires": {
-        "@cfworker/dev": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
         "@types/chai": "^4.2.16",
         "@types/mocha": "^8.2.2",
         "chai": "^4.3.4",
@@ -5794,9 +5794,9 @@
     "@cfworker/jwt": {
       "version": "file:packages/jwt",
       "requires": {
-        "@cfworker/base64url": "^1.10.1",
-        "@cfworker/dev": "^1.10.1",
-        "@cfworker/worker-types": "^1.10.1",
+        "@cfworker/base64url": "^1.10.2",
+        "@cfworker/dev": "^1.10.2",
+        "@cfworker/worker-types": "^1.10.2",
         "@cloudflare/workers-types": "^2.1.0",
         "@types/chai": "^4.2.16",
         "@types/mocha": "^8.2.2",
@@ -5808,7 +5808,7 @@
     "@cfworker/sentry": {
       "version": "file:packages/sentry",
       "requires": {
-        "@cfworker/worker-types": "^1.10.1",
+        "@cfworker/worker-types": "^1.10.2",
         "@cloudflare/workers-types": "^2.1.0",
         "typescript": "^4.5.2"
       }
@@ -5816,9 +5816,9 @@
     "@cfworker/site": {
       "version": "file:packages/site",
       "requires": {
-        "@cfworker/dev": "^1.10.1",
-        "@cfworker/web": "^1.10.1",
-        "@cfworker/worker-types": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
+        "@cfworker/web": "^1.10.2",
+        "@cfworker/worker-types": "^1.10.2",
         "@cloudflare/workers-types": "^2.1.0",
         "typescript": "^4.5.2"
       }
@@ -5826,7 +5826,7 @@
     "@cfworker/uuid": {
       "version": "file:packages/uuid",
       "requires": {
-        "@cfworker/dev": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
         "@types/chai": "^4.2.16",
         "@types/mocha": "^8.2.2",
         "chai": "^4.3.4",
@@ -5837,9 +5837,9 @@
     "@cfworker/web": {
       "version": "file:packages/web",
       "requires": {
-        "@cfworker/dev": "^1.10.1",
-        "@cfworker/json-schema": "^1.10.1",
-        "@cfworker/worker-types": "^1.10.1",
+        "@cfworker/dev": "^1.10.2",
+        "@cfworker/json-schema": "^1.10.2",
+        "@cfworker/worker-types": "^1.10.2",
         "@cloudflare/workers-types": "^2.1.0",
         "@types/chai": "^4.2.16",
         "@types/cookie": "^0.4.0",

--- a/packages/cosmos/src/client.ts
+++ b/packages/cosmos/src/client.ts
@@ -2,7 +2,7 @@ import { FeedResponse, ItemResponse } from './response.js';
 import { defaultRetryPolicy, RetryContext, RetryPolicy } from './retry.js';
 import { DefaultSessionContainer, SessionContainer } from './session.js';
 import { getSigner, Signer } from './signer.js';
-import {
+import type {
   Collection,
   ConsistencyLevel,
   Database,
@@ -11,6 +11,7 @@ import {
   IndexingPolicy,
   OfferType,
   PartitionKeyDefinition,
+  PartitionKeyRanges,
   Resource
 } from './types.js';
 import { assertArg, escapeNonASCII, uri } from './util.js';
@@ -451,24 +452,6 @@ function toBodyInit(obj: DocumentInit): BodyInit {
   }
   return JSON.stringify(obj);
 }
-
-type PartitionKeyRanges = {
-  _rid: string;
-  PartitionKeyRanges: {
-    _rid: string;
-    id: string;
-    _etag: string;
-    minInclusive: string;
-    maxExclusive: string;
-    ridPrefix: number;
-    _self: string;
-    throughputFraction: number;
-    status: string;
-    parents: unknown[];
-    _ts: number;
-  }[];
-  _count: number;
-};
 
 interface CommonArgs {
   activityId?: string;

--- a/packages/cosmos/src/client.ts
+++ b/packages/cosmos/src/client.ts
@@ -285,11 +285,7 @@ export class CosmosClient {
     this.setHeaders(request.headers, headers);
     request.headers.set('content-type', 'application/query+json');
     const response = await this.fetchWithRetry(request);
-    if (
-      (await response.clone().text()).includes(
-        'The provided cross partition query can not be directly served by the gateway'
-      )
-    ) {
+    if (response.headers.get('x-ms-substatus') === '1004') {
       const pkr: PartitionKeyRanges = await this.getPartitionKeyRanges({
         collId,
         dbId

--- a/packages/cosmos/src/types.ts
+++ b/packages/cosmos/src/types.ts
@@ -33,6 +33,31 @@ export type PartitionKeyRanges = {
   _count: number;
 };
 
+export type AdditionalErrorInfo = {
+  partitionedQueryExecutionInfoVersion: number;
+  queryInfo: {
+    distinctType: string;
+    top: number | null;
+    offset: number | null;
+    limit: number | null;
+    orderBy: 'Descending' | 'Ascending'[];
+    orderByExpressions: string[];
+    groupByExpressions: string[];
+    groupByAliases: string[];
+    aggregates: string[];
+    groupByAliasToAggregateType: unknown;
+    rewrittenQuery: string;
+    hasSelectValue: boolean;
+    dCountInfo: number | null;
+  };
+  queryRanges: {
+    min: string;
+    max: string;
+    isMinInclusive: boolean;
+    isMaxInclusive: boolean;
+  }[];
+};
+
 export interface Document extends PersistedResource {
   _attachments: 'attachments/';
 }

--- a/packages/cosmos/src/types.ts
+++ b/packages/cosmos/src/types.ts
@@ -17,6 +17,22 @@ export interface PersistedResource extends Resource {
   _ts: number;
 }
 
+export interface PartitionKeyRange extends PersistedResource {
+  id: string;
+  minInclusive: string;
+  maxExclusive: string;
+  ridPrefix: number;
+  throughputFraction: number;
+  status: string;
+  parents: unknown[];
+}
+
+export type PartitionKeyRanges = {
+  _rid: string;
+  PartitionKeyRanges: PartitionKeyRange[];
+  _count: number;
+};
+
 export interface Document extends PersistedResource {
   _attachments: 'attachments/';
 }


### PR DESCRIPTION
RE https://github.com/cfworker/cfworker/issues/123 and https://github.com/cfworker/cfworker/issues/168

This adds basic support for doing currently unsupported cross partition operations such as
- TOP
- ORDER BY
- OFFSET LIMIT
- Aggregates
- DISTINCT
- GROUP BY

It also adds the `getPartitionKeyRanges` function.

I have tested this with the following query:
```ts
await req.env.cosmos.queryDocuments<Listing>({
	collId: "theCollection",
	query: `SELECT * FROM c ORDER BY c.price DESC`,
	enableCrossPartition: true,
})
.then((res) => res.json());
```
and can confirm it's working.

I don't know if there are edge cases.
If this is run against a cosmos container with more than one physical partition it may fail as I do not know the proper request format to use for the final request if there are multiple partitions returned from `getPartitionKeyRanges`.