### PR TITLE
Add enableCrossPartitionQueries

### DIFF
--- a/packages/cosmos/src/client.ts
+++ b/packages/cosmos/src/client.ts
@@ -55,6 +55,11 @@ export interface CosmosClientConfig {
   sessions?: SessionContainer;
 
   /**
+   * Enables cross partition queries. This can be overriden on individual queries. Defaults to true.
+   */
+  enableCrossPartitionQueries?: boolean;
+
+  /**
    * System fetch function
    */
   fetch?: typeof fetch;
@@ -67,6 +72,7 @@ export class CosmosClient {
   private readonly consistencyLevel: ConsistencyLevel;
   private readonly dbId: string | undefined;
   private readonly collId: string | undefined;
+  private readonly enableCrossPartitionQueries: boolean;
   private readonly systemFetch: typeof fetch;
   public readonly sessions: SessionContainer;
   public requestCharges = 0;
@@ -79,6 +85,8 @@ export class CosmosClient {
     this.consistencyLevel = config.consistencyLevel ?? 'Session';
     this.dbId = config.dbId;
     this.collId = config.collId;
+    this.enableCrossPartitionQueries =
+      config.enableCrossPartitionQueries ?? true;
     this.sessions = config.sessions ?? new DefaultSessionContainer();
     this.systemFetch = config.fetch ?? fetch.bind(self);
   }

--- a/packages/cosmos/src/client.ts
+++ b/packages/cosmos/src/client.ts
@@ -278,7 +278,7 @@ export class CosmosClient {
 
     const headers = Object.assign(
       {
-        enableCrossPartition: false,
+        enableCrossPartition: this.enableCrossPartitionQueries,
         enableScan: false,
         maxItems: -1,
         populateMetrics: false,


### PR DESCRIPTION
RE https://github.com/cfworker/cfworker/pull/170

This adds the `enableCrossPartitionQueries`  as a option to `CosmosClientConfig` to be used in `queryDocuments` if `enableCrossPartition` is not specified in `QueryDocumentsArgs`.

Defaults to true re non cross partition deprication https://github.com/jupitern/cosmosdb/issues/3

I have not added tests for this as I don't know what you would want. This currently just extends the existing `enableCrossPartition` option from `QueryDocumentsArgs` to be set at the Client level.