### PR TITLE
Add getPartitionKeyRanges method and types

### DIFF
--- a/packages/cosmos/src/client.ts
+++ b/packages/cosmos/src/client.ts
@@ -300,6 +300,18 @@ export class CosmosClient {
     return new FeedResponse<T>(response, next, 'Documents');
   }
 
+  public async getPartitionKeyRanges(args: GetPartitionKeyRangesArgs) {
+    const { dbId = this.dbId, collId = this.collId } = args;
+    assertArg('dbId', dbId);
+    assertArg('collId', collId);
+
+    const url = this.endpoint + uri`/dbs/${dbId}/colls/${collId}/pkranges`;
+    const request = new Request(url);
+    this.setHeaders(request.headers, {});
+    request.headers.set('content-type', 'application/json');
+    return this.fetchWithRetry(request);
+  }
+
   private getNext<TArgs extends CommonGetListArgs, TResult>(
     response: Response,
     args: TArgs,
@@ -499,6 +511,11 @@ export interface QueryDocumentsArgs extends CommonGetListArgs {
   enableCrossPartition?: boolean;
   populateMetrics?: boolean;
   enableScan?: boolean;
+}
+
+export interface GetPartitionKeyRangesArgs extends CommonGetArgs {
+  dbId?: string;
+  collId?: string;
 }
 
 export interface QueryParameter {

--- a/packages/cosmos/src/types.ts
+++ b/packages/cosmos/src/types.ts
@@ -26,6 +26,22 @@ export interface Database extends PersistedResource {
   _users: 'users/';
 }
 
+export interface PartitionKeyRange extends PersistedResource {
+  id: string;
+  minInclusive: string;
+  maxExclusive: string;
+  ridPrefix: number;
+  throughputFraction: number;
+  status: string;
+  parents: unknown[];
+}
+
+export type PartitionKeyRanges = {
+  _rid: string;
+  PartitionKeyRanges: PartitionKeyRange[];
+  _count: number;
+};
+
 export interface IndexingPolicy {
   indexingMode: IndexingMode;
   automatic: boolean;


### PR DESCRIPTION
RE #170

This adds the `getPartitionKeyRanges` method & arg/return types for fetching `PartitionKeyRanges`.

I have not added tests.