### PR TITLE
Add an option to queryDocuments to specify the partition key range id

### DIFF
--- a/packages/cosmos/src/client.ts
+++ b/packages/cosmos/src/client.ts
@@ -496,6 +496,7 @@ export interface QueryDocumentsArgs extends CommonGetListArgs {
   query: string;
   parameters?: QueryParameter[];
   partitionKey?: string;
+  partitionKeyRangeId?: string;
   enableCrossPartition?: boolean;
   populateMetrics?: boolean;
   enableScan?: boolean;

--- a/packages/cosmos/src/client.ts
+++ b/packages/cosmos/src/client.ts
@@ -409,6 +409,12 @@ export class CosmosClient {
         args.enableCrossPartition.toString()
       );
     }
+    if (args.partitionKeyRangeId) {
+      headers.set(
+        'x-ms-documentdb-partitionkeyrangeid',
+        args.partitionKeyRangeId.toString()
+      );
+    }
   }
 }
 
@@ -551,4 +557,5 @@ interface AllHeaders {
   offerThroughput?: number;
   partitionKey?: string;
   populateMetrics?: boolean;
+  partitionKeyRangeId?: string;
 }


### PR DESCRIPTION
RE #170

This adds the optional `partitionKeyRangeId` arg for queryDocuments along with handling and types for `x-ms-documentdb-partitionkeyrangeid` in headers.

I have not added tests.