### PR TITLE
Allow authenticating to Cosmos DB with a connection string

### DIFF
--- a/.changeset/cuddly-bottles-smell.md
+++ b/.changeset/cuddly-bottles-smell.md
@@ -1,0 +1,5 @@
+---
+'@cfworker/cosmos': patch
+---
+
+Allow authenticating with Cosmos DB using a connection string

--- a/packages/cosmos/src/client.ts
+++ b/packages/cosmos/src/client.ts
@@ -99,7 +99,7 @@ export class CosmosClient {
       this.endpoint = config.endpoint;
       this.signer = getSigner(config.masterKey);
     } else {
-      throw Error(
+      throw new Error(
         'Either connectionString or endpoint/masterKey must be set in the config object'
       );
     }

--- a/packages/cosmos/src/util.ts
+++ b/packages/cosmos/src/util.ts
@@ -50,7 +50,7 @@ export function parseConnectionString(
     }
   });
   if (!res.AccountEndpoint || !res.AccountKey) {
-    throw Error('Failed to parse the connection string');
+    throw new Error('Failed to parse the connection string');
   }
   return res;
 }

--- a/packages/cosmos/src/util.ts
+++ b/packages/cosmos/src/util.ts
@@ -29,3 +29,37 @@ export function uri(strings: TemplateStringsArray, ...values: any[]) {
   }
   return s;
 }
+
+/**
+ * Parses a connection string for Cosmos DB.
+ * @param connString Cosmos DB connection string.
+ */
+export function parseConnectionString(
+  connString: string
+): CosmosDBConnectionStringParams {
+  const res = {} as CosmosDBConnectionStringParams;
+  connString.split(';').forEach(kv => {
+    const pos = kv.indexOf('=');
+    if (pos < 1) {
+      return;
+    }
+    const key = kv.slice(0, pos);
+    const val = kv.slice(pos);
+    if (key && val) {
+      res[key] = val;
+    }
+  });
+  if (!res.AccountEndpoint || !res.AccountKey) {
+    throw Error('Failed to parse the connection string');
+  }
+  return res;
+}
+
+/**
+ * Contains the parameters extracted from a Cosmos DB connection string.
+ */
+export interface CosmosDBConnectionStringParams {
+  AccountEndpoint: string;
+  AccountKey: string;
+  [k: string]: string;
+}

--- a/packages/cosmos/src/util.ts
+++ b/packages/cosmos/src/util.ts
@@ -44,7 +44,7 @@ export function parseConnectionString(
       return;
     }
     const key = kv.slice(0, pos);
-    const val = kv.slice(pos);
+    const val = kv.slice(pos + 1);
     if (key && val) {
       res[key] = val;
     }

--- a/packages/cosmos/test/client.integration.spec.ts
+++ b/packages/cosmos/test/client.integration.spec.ts
@@ -19,6 +19,21 @@ if (process.env.COSMOS_DB_ORIGIN) {
     kind: 'Hash'
   };
 
+  if (process.env.COSMOS_DB_CONNSTRING) {
+    const connectionString = process.env.COSMOS_DB_CONNSTRING;
+
+    describe('CosmosClient from connection string', () => {
+      const client = new CosmosClient({ connectionString, dbId, collId });
+
+      it(`"${dbId}" database  exists`, async () => {
+        const res = await client.getDatabase();
+        expect(res.status).to.equal(200);
+        const db = await res.json();
+        expect(db.id).to.equal(dbId);
+      });
+    });
+  }
+
   describe('CosmosClient', () => {
     const client = new CosmosClient({ endpoint, masterKey, dbId, collId });
 

--- a/packages/cosmos/test/util.spec.ts
+++ b/packages/cosmos/test/util.spec.ts
@@ -35,7 +35,7 @@ describe('util', () => {
         parseConnectionString(
           'AccountEndpoint=https://foo.documents.azure.com:443/;AccountKey=hello-world;'
         )
-      ).to.equal({
+      ).to.deep.equal({
         AccountEndpoint: 'https://foo.documents.azure.com:443/',
         AccountKey: 'hello-world'
       });

--- a/packages/cosmos/test/util.spec.ts
+++ b/packages/cosmos/test/util.spec.ts
@@ -1,6 +1,10 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { assertArg, escapeNonASCII } from '../src/index.js';
+import {
+  assertArg,
+  escapeNonASCII,
+  parseConnectionString
+} from '../src/index.js';
 
 describe('util', () => {
   describe('escapeNonASCII', () => {
@@ -22,6 +26,23 @@ describe('util', () => {
 
     it('does not throw when value is defined', () => {
       expect(() => assertArg('foo', 'bar')).not.to.throw();
+    });
+  });
+
+  describe('parseConnectionString', () => {
+    it('parses a connection string', () => {
+      expect(
+        parseConnectionString(
+          'AccountEndpoint=https://foo.documents.azure.com:443/;AccountKey=hello-world;'
+        )
+      ).to.equal({
+        AccountEndpoint: 'https://foo.documents.azure.com:443/',
+        AccountKey: 'hello-world'
+      });
+    });
+
+    it('throws when value is invalid', () => {
+      expect(() => parseConnectionString('foo')).to.throw();
     });
   });
 });


### PR DESCRIPTION
This allows authenticating to Cosmos DB using a connection string as they are often found in the Azure Portal. This requires only 1 option rather than 2.