### PR TITLE
Fix auth issues when Cosmos DB endpoint had trailing slash

### DIFF
--- a/.changeset/seven-planes-compete.md
+++ b/.changeset/seven-planes-compete.md
@@ -1,0 +1,5 @@
+---
+"@cfworker/cosmos": patch
+---
+
+Fix auth issues when Cosmos DB endpoint had trailing slash

--- a/packages/cosmos/src/client.ts
+++ b/packages/cosmos/src/client.ts
@@ -81,6 +81,9 @@ export class CosmosClient {
   constructor(config: CosmosClientConfig) {
     this.endpoint = config.endpoint;
     this.signer = getSigner(config.masterKey);
+    if (this.endpoint.endsWith('/')) {
+      this.endpoint = this.endpoint.slice(0, -1);
+    }
     this.retryPolicy = config.retryPolicy ?? defaultRetryPolicy;
     this.consistencyLevel = config.consistencyLevel ?? 'Session';
     this.dbId = config.dbId;


### PR DESCRIPTION
When the Cosmos DB's endpoint has a trailing slash (e.g. `https://foo.documents.azure.com/`), auth was failing.
Note that this is independent from #198 (but it applies to when that PR is merged too, as connection strings by default do include the trailing slash)