### PR TITLE
Fix prefixItems type definition

### DIFF
--- a/.changeset/sour-dots-whisper.md
+++ b/.changeset/sour-dots-whisper.md
@@ -1,0 +1,5 @@
+---
+"@cfworker/json-schema": patch
+---
+
+Fix prefixItems type definition

--- a/packages/json-schema/src/types.ts
+++ b/packages/json-schema/src/types.ts
@@ -51,7 +51,7 @@ export interface Schema {
   dependentSchemas?: Record<string, Schema>;
   dependencies?: Record<string, Schema | string[]>;
 
-  prefixItems?: Array<Schema | boolean>[];
+  prefixItems?: Array<Schema | boolean>;
   items?: Schema | boolean | Array<Schema | boolean>;
   additionalItems?: Schema | boolean;
   unevaluatedItems?: Schema | boolean;


### PR DESCRIPTION
prefixItems has a bad type definition which result in it being defined as `(boolean | Schema)[][]`