### PR TITLE
Specify uuid package as a module

### DIFF
--- a/packages/uuid/package.json
+++ b/packages/uuid/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@cfworker/uuid",
+  "type": "module",
   "version": "1.12.4",
   "description": "Serialize/deserialize V4 UUIDs from a Uint8Array",
   "keywords": [


### PR DESCRIPTION
Related to https://github.com/cfworker/cfworker/issues/240

When using jest to test a cf worker that imports uuid, jest fails to treat uuid as an ES module.

Fixes jest failure for:
```
    export function uuid(arr) {
    ^^^^^^

    SyntaxError: Unexpected token 'export'
```