### PR TITLE
Add exports field and CommonJS support to @cfworker/cfworker for compatibility with Custom Entrypoint builds

### DIFF
--- a/.changeset/blue-deers-move.md
+++ b/.changeset/blue-deers-move.md
@@ -1,0 +1,12 @@
+---
+"@cfworker/cosmos": major
+"@cfworker/csv": major
+"@cfworker/examples": major
+"@cfworker/json-schema": major
+"@cfworker/jwt": major
+"@cfworker/sentry": major
+"@cfworker/uuid": major
+"@cfworker/web": major
+---
+
+Add support for CommonJS by adding exports field to all packages. Thanks @dannyball710 !!

--- a/package-lock.json
+++ b/package-lock.json
@@ -4655,7 +4655,7 @@
     },
     "packages/csv": {
       "name": "@cfworker/csv",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.3.17",
@@ -4699,7 +4699,7 @@
     },
     "packages/jwt": {
       "name": "@cfworker/jwt",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "license": "MIT",
       "dependencies": {
         "rfc4648": "^1.5.3"

--- a/packages/cosmos/package.json
+++ b/packages/cosmos/package.json
@@ -14,16 +14,20 @@
     "service-worker"
   ],
   "sideEffects": false,
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "source": "src/index.ts",
-  "types": "dist/index.d.ts",
+  "types": "dist/esm/index.d.ts",
   "files": [
     "dist/**/*",
     "src/**/*",
     "README.md",
     "package.json"
   ],
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "repository": "https://github.com/cfworker/cfworker",
   "author": "Jeremy Danyow <jdanyow@gmail.com>",
   "homepage": "https://github.com/cfworker/cfworker/tree/master/packages/cosmos/README.md",
@@ -32,7 +36,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build & tsc --build tsconfig-cjs.json",
     "clean": "tsc --build --clean",
     "pretest": "esbuild test/test.ts --target=esnext --bundle --format=esm --conditions=worker,browser --outdir=dist-test --ignore-annotations",
     "test": "node ../../test.mjs"

--- a/packages/cosmos/tsconfig-cjs.json
+++ b/packages/cosmos/tsconfig-cjs.json
@@ -1,12 +1,11 @@
 {
   "extends": "../../tsconfig-base",
   "compilerOptions": {
+    "module": "CommonJS",
     "target": "ESNext",
     "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "outDir": "dist/esm",
+    "outDir": "dist/cjs",
     "rootDir": "./src"
   },
-
-  "include": ["src"],
-  "references": [{ "path": "../json-schema" }]
+  "include": ["src"]
 }

--- a/packages/cosmos/tsconfig.json
+++ b/packages/cosmos/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "rootDir": "./src"
   },
   "include": ["src"]

--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -4,16 +4,20 @@
   "version": "2.2.0",
   "description": "Streaming CSV encoding for Cloudflare Workers and service workers",
   "sideEffects": false,
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "source": "src/index.ts",
-  "types": "dist/index.d.ts",
+  "types": "dist/esm/index.d.ts",
   "files": [
     "dist/**/*",
     "src/**/*",
     "README.md",
     "package.json"
   ],
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "repository": "https://github.com/cfworker/cfworker",
   "author": "Jeremy Danyow <jdanyow@gmail.com>",
   "homepage": "https://github.com/cfworker/cfworker/tree/master/packages/csv/README.md",
@@ -22,7 +26,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build & tsc --build tsconfig-cjs.json",
     "clean": "tsc --build --clean",
     "pretest": "esbuild test/test.ts --target=esnext --bundle --format=esm --conditions=worker,browser --outdir=dist-test --ignore-annotations",
     "test": "node ../../test.mjs"

--- a/packages/csv/tsconfig-cjs.json
+++ b/packages/csv/tsconfig-cjs.json
@@ -1,12 +1,11 @@
 {
   "extends": "../../tsconfig-base",
   "compilerOptions": {
+    "module": "CommonJS",
     "target": "ESNext",
     "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "outDir": "dist/esm",
+    "outDir": "dist/cjs",
     "rootDir": "./src"
   },
-
-  "include": ["src"],
-  "references": [{ "path": "../json-schema" }]
+  "include": ["src"]
 }

--- a/packages/csv/tsconfig.json
+++ b/packages/csv/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "rootDir": "./src"
   },
   "include": ["src"]

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -3,7 +3,11 @@
   "type": "module",
   "version": "2.1.0",
   "description": "cfworker examples",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "repository": "https://github.com/cfworker/cfworker",
   "author": "Jeremy Danyow <jdanyow@gmail.com>",
   "homepage": "https://github.com/cfworker/cfworker/tree/master/packages/examples/README.md",

--- a/packages/examples/tsconfig-cjs.json
+++ b/packages/examples/tsconfig-cjs.json
@@ -1,12 +1,10 @@
 {
   "extends": "../../tsconfig-base",
   "compilerOptions": {
+    "module": "CommonJS",
     "target": "ESNext",
     "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "outDir": "dist/esm",
-    "rootDir": "./src"
-  },
-
-  "include": ["src"],
-  "references": [{ "path": "../json-schema" }]
+    "composite": false,
+    "outDir": "dist/cjs"
+  }
 }

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "composite": false
+    "composite": false,
+    "outDir": "dist/esm"
   }
 }

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -14,15 +14,19 @@
     "service-worker"
   ],
   "sideEffects": false,
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
   "files": [
     "dist/**/*",
     "src/**/*",
     "README.md",
     "package.json"
   ],
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "repository": "https://github.com/cfworker/cfworker",
   "author": "Jeremy Danyow <jdanyow@gmail.com>",
   "homepage": "https://github.com/cfworker/cfworker/tree/master/packages/json-schema/README.md",
@@ -31,7 +35,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build & tsc --build tsconfig-cjs.json",
     "clean": "tsc --build --clean",
     "pretest": "node --experimental-import-meta-resolve suite-gen.js && esbuild test/test.ts --target=esnext --bundle --format=esm --conditions=worker,browser --outdir=dist-test --ignore-annotations",
     "test": "node ../../test.mjs"

--- a/packages/json-schema/tsconfig-cjs.json
+++ b/packages/json-schema/tsconfig-cjs.json
@@ -1,12 +1,11 @@
 {
   "extends": "../../tsconfig-base",
   "compilerOptions": {
+    "module": "CommonJS",
     "target": "ESNext",
     "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "outDir": "dist/esm",
+    "outDir": "dist/cjs",
     "rootDir": "./src"
   },
-
-  "include": ["src"],
-  "references": [{ "path": "../json-schema" }]
+  "include": ["src"]
 }

--- a/packages/json-schema/tsconfig.json
+++ b/packages/json-schema/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "rootDir": "./src"
   },
   "include": ["src"]

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -11,16 +11,20 @@
     "workers",
     "service-worker"
   ],
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/cjs/index.js",
   "source": "src/index.ts",
-  "types": "dist/index.d.ts",
+  "types": "dist/cjs/index.d.ts",
   "files": [
     "dist/**/*",
     "src/**/*",
     "README.md",
     "package.json"
   ],
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "repository": "https://github.com/cfworker/cfworker",
   "author": "Jeremy Danyow <jdanyow@gmail.com>",
   "homepage": "https://github.com/cfworker/cfworker/tree/master/packages/jwt/README.md",
@@ -29,7 +33,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build & tsc --build tsconfig-cjs.json",
     "clean": "tsc --build --clean",
     "pretest": "esbuild test/test.ts --target=esnext --bundle --format=esm --conditions=worker,browser --outdir=dist-test --ignore-annotations",
     "test": "node ../../test.mjs"

--- a/packages/jwt/tsconfig-cjs.json
+++ b/packages/jwt/tsconfig-cjs.json
@@ -1,12 +1,12 @@
 {
   "extends": "../../tsconfig-base",
   "compilerOptions": {
+    "module": "CommonJS",
     "target": "ESNext",
     "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "outDir": "dist/esm",
+    "outDir": "dist/cjs",
     "rootDir": "./src"
   },
-
   "include": ["src"],
-  "references": [{ "path": "../json-schema" }]
+  "references": []
 }

--- a/packages/jwt/tsconfig.json
+++ b/packages/jwt/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "rootDir": "./src"
   },
   "include": ["src"],

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -12,16 +12,20 @@
     "service-worker"
   ],
   "sideEffects": false,
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "source": "src/index.ts",
-  "types": "dist/index.d.ts",
+  "types": "dist/esm/index.d.ts",
   "files": [
     "dist/**/*",
     "src/**/*",
     "README.md",
     "package.json"
   ],
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "repository": "https://github.com/cfworker/cfworker",
   "author": "Jeremy Danyow <jdanyow@gmail.com>",
   "homepage": "https://github.com/cfworker/cfworker/tree/master/packages/sentry/README.md",
@@ -30,7 +34,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build & tsc --build tsconfig-cjs.json",
     "clean": "tsc --build --clean",
     "test": "echo \"no tests 🥺\""
   },

--- a/packages/sentry/tsconfig-cjs.json
+++ b/packages/sentry/tsconfig-cjs.json
@@ -1,12 +1,12 @@
 {
   "extends": "../../tsconfig-base",
   "compilerOptions": {
+    "module": "CommonJS",
     "target": "ESNext",
     "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "outDir": "dist/esm",
+    "outDir": "dist/cjs",
     "rootDir": "./src"
   },
-
   "include": ["src"],
-  "references": [{ "path": "../json-schema" }]
+  "references": [{ "path": "../uuid" }]
 }

--- a/packages/sentry/tsconfig.json
+++ b/packages/sentry/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "rootDir": "./src"
   },
   "include": ["src"],

--- a/packages/uuid/package.json
+++ b/packages/uuid/package.json
@@ -13,16 +13,20 @@
     "service-worker"
   ],
   "sideEffects": false,
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "source": "src/index.ts",
-  "types": "dist/index.d.ts",
+  "types": "dist/esm/index.d.ts",
   "files": [
     "dist/**/*",
     "src/**/*",
     "README.md",
     "package.json"
   ],
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "repository": "https://github.com/cfworker/cfworker",
   "author": "Jeremy Danyow <jdanyow@gmail.com>",
   "homepage": "https://github.com/cfworker/cfworker/tree/master/packages/uuid/README.md",
@@ -31,7 +35,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build & tsc --build tsconfig-cjs.json",
     "clean": "tsc --build --clean",
     "pretest": "esbuild test/test.ts --target=esnext --bundle --format=esm --conditions=worker,browser --outdir=dist-test --ignore-annotations",
     "test": "node ../../test.mjs"

--- a/packages/uuid/tsconfig-cjs.json
+++ b/packages/uuid/tsconfig-cjs.json
@@ -1,12 +1,11 @@
 {
   "extends": "../../tsconfig-base",
   "compilerOptions": {
+    "module": "CommonJS",
     "target": "ESNext",
     "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "outDir": "dist/esm",
+    "outDir": "dist/cjs",
     "rootDir": "./src"
   },
-
-  "include": ["src"],
-  "references": [{ "path": "../json-schema" }]
+  "include": ["src"]
 }

--- a/packages/uuid/tsconfig.json
+++ b/packages/uuid/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "rootDir": "./src"
   },
   "include": ["src"]

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,16 +11,20 @@
     "service-worker"
   ],
   "sideEffects": false,
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "source": "src/index.ts",
-  "types": "dist/index.d.ts",
+  "types": "dist/esm/index.d.ts",
   "files": [
     "dist/**/*",
     "src/**/*",
     "README.md",
     "package.json"
   ],
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "repository": "https://github.com/cfworker/cfworker",
   "author": "Jeremy Danyow <jdanyow@gmail.com>",
   "homepage": "https://github.com/cfworker/cfworker/tree/master/packages/web/README.md",
@@ -29,7 +33,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build & tsc --build tsconfig-cjs.json",
     "clean": "tsc --build --clean",
     "pretest": "esbuild test/test.ts --target=esnext --bundle --format=esm --conditions=worker,browser --outdir=dist-test --ignore-annotations",
     "test": "node ../../test.mjs"

--- a/packages/web/tsconfig-cjs.json
+++ b/packages/web/tsconfig-cjs.json
@@ -1,9 +1,10 @@
 {
   "extends": "../../tsconfig-base",
   "compilerOptions": {
+    "module": "CommonJS",
     "target": "ESNext",
     "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
-    "outDir": "dist/esm",
+    "outDir": "dist/cjs",
     "rootDir": "./src"
   },
 


### PR DESCRIPTION
### Summary
While developing with `@cloudflare/next-on-pages`, I encountered an issue where modules from `@cfworker/cfworker` could not be imported correctly when building with a Custom Entrypoint. Investigation revealed that this was due to a missing `exports` field in the `@cfworker/cfworker` `package.json`, which prevented proper module resolution.

This PR adds an `exports` field to `@cfworker/cfworker`'s `package.json` and includes CommonJS support to resolve this issue.

### Changes
- Added a CommonJS compilation version.
- Updated `package.json` to include an `exports` field with paths for both ESM (`import`) and CommonJS (`require`).