### PR TITLE
close retryRequest body readablestream after fetch

### DIFF
--- a/.changeset/afraid-days-wave.md
+++ b/.changeset/afraid-days-wave.md
@@ -1,0 +1,5 @@
+---
+'@cfworker/cosmos': patch
+---
+
+Cancel retryRequest body after successful fetch. This removes the `A ReadableStream branch was created but never consumed...` error shown during debugging.

--- a/packages/cosmos/src/client.ts
+++ b/packages/cosmos/src/client.ts
@@ -357,6 +357,7 @@ export class CosmosClient {
 
     const { retry, delayMs } = await this.retryPolicy.shouldRetry(context);
     if (!retry) {
+      retryRequest.body?.cancel();
       return response;
     }
     if (delayMs !== 0) {


### PR DESCRIPTION
## Changes

- Fixes https://github.com/cfworker/cfworker/issues/245
- Stops the following warning appearing during debug:

![image](https://github.com/user-attachments/assets/f67fe0d7-ffa8-439d-9dbd-21a06a6e17a2)


